### PR TITLE
Updated to capacity lut to nov 2017 data and generated average speed by only technology

### DIFF
--- a/scripts/capacity_lut_preprocess.py
+++ b/scripts/capacity_lut_preprocess.py
@@ -18,25 +18,29 @@ LUT_OUTPUT_FIXED = os.path.join(BASE_PATH, 'processed')
 # READ LOOK UP TABLE (LUT) DATA
 #####################################
 
-def read_capacity_lut():
+def read_capacity_lut(data_name, folder_year, column1, column2, column3, column4):
     """
 
     """
     capacity_lut_data = []
-    with open(os.path.join(LUT_INPUT_FIXED, 'UK-home-broadband-performance-2017-panellist-data.csv'), 'r', encoding='utf8', errors='replace') as system_file:
+    with open(os.path.join(LUT_INPUT_FIXED, folder_year, data_name), 'r', encoding='utf8', errors='replace') as system_file:
         reader = csv.reader(system_file)
         next(reader)
         for line in reader:
             capacity_lut_data.append({
-                'urban_rural': line[4],
-                'distance': line[5],
-                'technology': line[6],
-                'mean_speed': float(line[8]),
+                #'urban_rural': line[column1],
+                #'distance': float(line[column2]),
+                'technology': line[column3],
+                'mean_speed': float(line[column4])
             })     
  
         return capacity_lut_data
 
-def find_mean_capacity():
+##################################################################
+# FIND MEAN CAPACITY BASED ON URBAN_RURAL, DISTANCE AND TECHNOLOGY
+##################################################################
+
+def find_mean_capacity_urban_distance_technology():
     """
 
     """
@@ -47,6 +51,25 @@ def find_mean_capacity():
         dic[key].append(d['mean_speed'])
         
         mean = [{"urban_rural":key[0], "distance":key[1], "technology":key[2], "mean_speed":sum(val)/len(val)}
+            for key,val in dic.items()]
+
+    return mean
+
+##################################################################
+# FIND MEAN CAPACITY BASED ON URBAN_RURAL AND TECHNOLOGY
+##################################################################
+
+def find_mean_capacity_urban_technology(data):
+    """
+
+    """
+    dic = {}
+    for d in data:
+        key = d['technology']
+        if key not in dic: dic[key] = []
+        dic[key].append(d['mean_speed'])
+        
+        mean = [{"technology":key, "mean_speed":round(sum(val)/len(val), 1)}
             for key,val in dic.items()]
 
     return mean
@@ -70,10 +93,10 @@ def csv_writer(data, filename):
 #####################################
 
 #read LUT
-capacity_lut = read_capacity_lut()
+capacity_lut = read_capacity_lut('panellist-data_November_2017.csv', '2017', 11, 5, 6, 14)
 
 #find mean capacity
-mean_capacity_lut = find_mean_capacity()
+mean_capacity_lut = find_mean_capacity_urban_technology(capacity_lut)
 
 #write to .csv file
-csv_writer(mean_capacity_lut, 'fixed_capacity_lut.csv')
+csv_writer(mean_capacity_lut, 'fixed_capacity_lut_nov_2017.csv')


### PR DESCRIPTION
Updated to newest data. Previously we were generating the LUT by multiple other categories. In general, the difference in connection capacity results mainly from the enabling technology, therefore I simplified this to focus (for now) on just the basic ~5 broadband technologies. 