### PR TITLE
Tweaks to aid nismod2 integration

### DIFF
--- a/digital_comms/fixed_network/adoption.py
+++ b/digital_comms/fixed_network/adoption.py
@@ -6,7 +6,8 @@ from logging import getLogger
 
 LOGGER = getLogger(__name__)
 
-def update_adoption_desirability(system, annual_adoption_rate):
+
+def update_adoption_desirability(distributions, annual_adoption_rate):
     """
     Given adoption parameters and a set of distribution points, return likely adoptees.
 
@@ -16,38 +17,42 @@ def update_adoption_desirability(system, annual_adoption_rate):
     2) rank distribution points based on wta
     3) select top n % of new premises wanting to adopt
 
+    Arguments
+    ---------
+    distributions : digital_comms.fixed_network.Distribution
+    annual_adoption_rate
     """
 
-    #Step 1
-    #Work out the number of raw new premises wanting to adopt in a single year
+    # Step 1
+    # Work out the number of raw new premises wanting to adopt in a single year
     distributions_already_wanting_to_adopt = [
-        distribution for distribution in system._distributions
+        distribution for distribution in distributions
         if distribution.adoption_desirability is True
     ]
 
-    #get total premises needing to be served in current system
+    # get total premises needing to be served in current system
     count_of_premises_already_wanting_to_adopt = 0
     for distribution in distributions_already_wanting_to_adopt:
         count_of_premises_already_wanting_to_adopt += distribution.total_prems
 
-    #get total premises needing to be served in current system
+    # get total premises needing to be served in current system
     total_premises = 0
-    for distribution in system._distributions:
+    for distribution in distributions:
         total_premises += distribution.total_prems
 
-    #get raw annual premises adoption
+    # get raw annual premises adoption
     raw_annual_premises_adoption = round(total_premises*(annual_adoption_rate/100))
 
-    #get raw new premises wanting to adopt
+    # get raw new premises wanting to adopt
     raw_new_premises_wanting_to_adopt = (
         raw_annual_premises_adoption - count_of_premises_already_wanting_to_adopt)
 
     distributions_not_wanting_to_adopt = [
-        distribution for distribution in system._distributions
+        distribution for distribution in distributions
         if distribution.adoption_desirability is not True
     ]
 
-    #rank distributions based on household wta
+    # rank distributions based on household wta
     distributions_not_wanting_to_adopt = sorted(
         distributions_not_wanting_to_adopt, key=lambda item: item.wta, reverse=True)
 
@@ -61,22 +66,22 @@ def update_adoption_desirability(system, annual_adoption_rate):
             break
 
     LOGGER.debug("-- premises not wanting to connect %s",
-        len([dist.total_prems for dist in distributions_not_wanting_to_adopt]))
+                 len([dist.total_prems for dist in distributions_not_wanting_to_adopt]))
     LOGGER.debug("-- premises wanting to connect %s",
-        sum([dist.total_prems for dist in new_distributions_wanting_to_adopt]))
+                 sum([dist.total_prems for dist in new_distributions_wanting_to_adopt]))
     LOGGER.debug("-- total premises %s",
-        sum([dist.total_prems for dist in distributions_already_wanting_to_adopt]) +
-        sum([dist.total_prems for dist in distributions_not_wanting_to_adopt]))
+                 sum([dist.total_prems for dist in distributions_already_wanting_to_adopt]) +
+                 sum([dist.total_prems for dist in distributions_not_wanting_to_adopt]))
 
     distribution_adoption = []
 
-    #cycle through number of premises
+    # cycle through number of premises
     for distribution in new_distributions_wanting_to_adopt:
 
-        #turn adoption_desirability to True
+        # turn adoption_desirability to True
         distribution.adoption_desirability = True
 
-        #append adopted premises to list
+        # append adopted premises to list
         distribution_adoption.append((distribution.id, distribution.adoption_desirability))
 
     return distribution_adoption

--- a/digital_comms/fixed_network/interventions.py
+++ b/digital_comms/fixed_network/interventions.py
@@ -7,16 +7,16 @@
 ################################################################
 
 
-def get_all_distributions_ranked(system, ranking_variable, technology, reverse_value):
+def get_all_distributions_ranked(distributions, ranking_variable, technology, reverse_value):
     """Specifically obtain and rank Distribution Points by technology and policy.
 
     Parameters
     ----------
-    system : object
-        This is an NetworkManager object containing the whole system.
-    technology : string
+    distributions : list of digital_comms.fixed_network.model.Distribution
+        A list of distribution points
+    technology : str
         The current technology being deployed.
-    reverse_value : boolean
+    reverse_value : bool
         Used as an argument in 'sorted' to rank how assets will be deployed.
 
     Returns
@@ -27,25 +27,27 @@ def get_all_distributions_ranked(system, ranking_variable, technology, reverse_v
 
     """
     if ranking_variable == 'rollout_benefits':
-        distributions = sorted(system._distributions,
-            key=lambda item: item.rollout_benefits[technology], reverse=reverse_value)
+        distributions = sorted(distributions,
+                               key=lambda item: item.rollout_benefits[technology],
+                               reverse=reverse_value)
     elif ranking_variable == 'rollout_costs':
-        distributions = sorted(system._distributions,
-            key=lambda item: item.rollout_costs[technology], reverse=reverse_value)
+        distributions = sorted(distributions,
+                               key=lambda item: item.rollout_costs[technology],
+                               reverse=reverse_value)
     else:
         print('Did not recognise ranking preference variable')
 
     return distributions
 
 
-def decide_interventions(system, year, technology, policy, annual_budget, adoption_cap,
+def decide_interventions(distributions, year, technology, policy, annual_budget, adoption_cap,
                          subsidy, telco_match_funding, service_obligation_capacity):
     """Given strategy parameters and a system, decide the best potential interventions.
 
     Parameters
     ----------
-    system : object
-        This is an NetworkManager object containing the whole system.
+    distributions : list of digital_comms.fixed_network.model.Distribution
+        A list of distribution points
     year : int
         The current year.
     technology : string
@@ -70,28 +72,30 @@ def decide_interventions(system, year, technology, policy, annual_budget, adopti
 
     """
     # Build to meet demand most beneficial demand
-    built_interventions = meet_most_beneficial_demand(system, year, technology, policy, annual_budget, adoption_cap,
-                                                        subsidy, telco_match_funding, service_obligation_capacity)
+    built_interventions = meet_most_beneficial_demand(distributions, year, technology, policy, annual_budget,
+                                                      adoption_cap, subsidy, telco_match_funding,
+                                                      service_obligation_capacity)
 
     return built_interventions
 
-def meet_most_beneficial_demand(system, year, technology, policy, annual_budget, adoption_cap,
+def meet_most_beneficial_demand(distributions, year, technology, policy, annual_budget, adoption_cap,
                                 subsidy, telco_match_funding, service_obligation_capacity):
-    """Given strategy parameters and a system, meet the most beneficial demand.
+    """Given strategy parameters and a list of distribution points, meet the most beneficial demand.
 
     TODO: address service_obligation_capacity here.
 
     """
     return _suggest_interventions(
-        system, year, technology, policy, annual_budget, adoption_cap, subsidy, telco_match_funding)
+        distributions, year, technology, policy, annual_budget, adoption_cap, subsidy, telco_match_funding)
 
-def _suggest_interventions(system, year, technology, policy, annual_budget, adoption_cap, subsidy, telco_match_funding):
+def _suggest_interventions(distributions, year, technology, policy, annual_budget, adoption_cap, subsidy,
+                           telco_match_funding):
     """Given strategy parameters and a system, suggest the best potential interventions.
 
     Parameters
     ----------
-    system : object
-        This is an NetworkManger object containing the whole system.
+    distributions : list of digital_comms.fixed_network.model.Distribution
+        A list of distribution points
     year : int
         The current year.
     technology : string
@@ -120,7 +124,7 @@ def _suggest_interventions(system, year, technology, policy, annual_budget, adop
     premises_passed = 0
 
     if policy == 's1_market_based_roll_out':
-        distributions = get_all_distributions_ranked(system, 'rollout_benefits', technology, False)
+        distributions = get_all_distributions_ranked(distributions, 'rollout_benefits', technology, False)
         for distribution in distributions:
             if distribution.id not in upgraded_ids:
                 if (premises_passed + distribution.total_prems) < adoption_cap:
@@ -144,9 +148,9 @@ def _suggest_interventions(system, year, technology, policy, annual_budget, adop
                     break
 
     elif policy == 's2_rural_based_subsidy' or 's3_outside_in_subsidy':
-        distributions = get_all_distributions_ranked(system, 'rollout_benefits',technology, False)
+        ranked_distributions = get_all_distributions_ranked(distributions, 'rollout_benefits',technology, False)
         deployment_type = 'market_based'
-        for distribution in distributions:
+        for distribution in ranked_distributions:
             if distribution.id not in upgraded_ids:
                 if (premises_passed + distribution.total_prems) < adoption_cap:
                     if distribution.rollout_costs[technology] < annual_budget:
@@ -174,7 +178,7 @@ def _suggest_interventions(system, year, technology, policy, annual_budget, adop
         else:
             print('policy not recognised')
 
-        subsidised_distributions = get_all_distributions_ranked(system, 'rollout_costs', technology, reverse_value)
+        subsidised_distributions = get_all_distributions_ranked(distributions, 'rollout_costs', technology, reverse_value)
 
         # # get the bottom third of the distribution cutoff point
         # subsidy_cutoff = math.floor(len(subsidised_distributions) * 0.66)

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -725,6 +725,7 @@ class Distribution():
     def update_desirability_to_adopt(self, desirability_to_adopt):
         self.adoption_desirability = desirability_to_adopt
 
+
 class Link():
     """Link object
 

--- a/digital_comms/runner.py
+++ b/digital_comms/runner.py
@@ -366,7 +366,7 @@ def run():
 
             # update the number of premises wanting to adopt (adoption_desirability)
             distribution_adoption_desirability_ids = update_adoption_desirability(
-                system, percentage_annual_increase)
+                system._distributions, percentage_annual_increase)
 
             # system.update_adoption_desirability(distribution_adoption_desirability_ids)
 

--- a/digital_comms/runner.py
+++ b/digital_comms/runner.py
@@ -34,7 +34,7 @@ def read_csv(file):
     return results
 
 
-def read_assets():
+def read_assets(data_path):
     """Read in all assets required to run the model:
         - Exchanges
         - Cabinets
@@ -48,16 +48,16 @@ def read_assets():
     """
     assets = {}
     assets['exchanges'] = read_csv(os.path.join(
-        'data', 'processed', 'assets_exchanges.csv'))
+        data_path, 'assets_exchanges.csv'))
     assets['cabinets'] = read_csv(os.path.join(
-        'data', 'processed', 'assets_cabinets.csv'))
+        data_path, 'assets_cabinets.csv'))
     assets['distributions'] = read_csv(os.path.join(
-        'data', 'processed', 'assets_distribution_points.csv'))
+        data_path, 'assets_distribution_points.csv'))
 
     return assets
 
 
-def read_links():
+def read_links(data_path):
     """Read in all links required to run the model:
         - Exchange to Cabinets
         - Cabinets to Distribution Points
@@ -71,9 +71,9 @@ def read_links():
 
     """
     links = []
-    links.extend(read_csv(os.path.join('data', 'processed', 'links_distribution_points.csv')))
-    links.extend(read_csv(os.path.join('data', 'processed', 'links_cabinets.csv')))
-    links.extend(read_csv(os.path.join('data', 'processed', 'links_exchanges.csv')))
+    links.extend(read_csv(os.path.join(data_path, 'links_distribution_points.csv')))
+    links.extend(read_csv(os.path.join(data_path, 'links_cabinets.csv')))
+    links.extend(read_csv(os.path.join(data_path, 'links_exchanges.csv')))
 
     return links
 

--- a/digital_comms/runner.py
+++ b/digital_comms/runner.py
@@ -12,12 +12,12 @@ from digital_comms.fixed_network.interventions import decide_interventions
 from digital_comms.fixed_network.adoption import update_adoption_desirability
 
 
-def read_csv(file):
+def read_csv(filepath):
     """Read in a .csv file. Convert each line to single dict, and then append to a list.
 
     Parameters
     ----------
-    file : string
+    filepath : string
         This is a directory string to point to the desired file from the BASE_PATH.
 
     Returns
@@ -27,18 +27,25 @@ def read_csv(file):
         dict
 
     """
-    with open(file, 'r') as system_file:
-        reader = csv.DictReader(system_file)
+    with open(filepath, 'r') as csvfile:
+        reader = csv.DictReader(csvfile)
         results = list(reader)
 
     return results
 
 
 def read_assets(data_path):
-    """Read in all assets required to run the model:
+    """Read in all assets required to run the model
+
+    Reads in data for
         - Exchanges
         - Cabinets
         - Distribution Points
+
+    Arguments
+    ---------
+    data_path : str
+        Path to folder which contains the asset files
 
     Returns
     -------
@@ -58,10 +65,17 @@ def read_assets(data_path):
 
 
 def read_links(data_path):
-    """Read in all links required to run the model:
+    """Read in all links required to run the model
+
+    Reads in
         - Exchange to Cabinets
         - Cabinets to Distribution Points
         - Distribution Points to Premises in aggregated form
+
+    Arguments
+    ---------
+    data_path : str
+        Path to folder which contains the asset files
 
     Returns
     -------
@@ -71,9 +85,11 @@ def read_links(data_path):
 
     """
     links = []
-    links.extend(read_csv(os.path.join(data_path, 'links_distribution_points.csv')))
-    links.extend(read_csv(os.path.join(data_path, 'links_cabinets.csv')))
-    links.extend(read_csv(os.path.join(data_path, 'links_exchanges.csv')))
+    files = ['links_distribution_points.csv',
+             'links_cabinets.csv',
+             'links_exchanges.csv']
+    for filename in files:
+        links.extend(read_csv(os.path.join(data_path, filename)))
 
     return links
 
@@ -299,6 +315,7 @@ def write_spend(decisions, year, technology, policy):
 # RUN MODEL
 ################################################################
 
+
 def run():
     """Run model over scenario/strategy combinations
     """
@@ -314,8 +331,9 @@ def run():
         logging.info("Running: %s, %s, %s", scenario, technology, policy)
         logging.info("--")
 
-        assets = read_assets()
-        links = read_links()
+        data_path = os.path.join('data', 'processed')
+        assets = read_assets(data_path)
+        links = read_links(data_path)
         parameters = read_parameters()
 
         for year in TIMESTEPS:

--- a/digital_comms/runner.py
+++ b/digital_comms/runner.py
@@ -93,56 +93,8 @@ def read_parameters():
     with open(path, 'r') as ymlfile:
         for data in yaml.load_all(ymlfile):
             parameters = data['parameters']
-            for param in parameters:
-                if param['name'] == 'costs_assets_exchange_fttp':
-                    params['costs_assets_exchange_fttp'] = param['default_value']
-                if param['name'] == 'costs_assets_exchange_fttdp':
-                    params['costs_assets_exchange_fttdp'] = param['default_value']
-                if param['name'] == 'costs_assets_exchange_fttc':
-                    params['costs_assets_exchange_fttc'] = param['default_value']
-                if param['name'] == 'costs_assets_exchange_adsl':
-                    params['costs_assets_exchange_adsl'] = param['default_value']
-                if param['name'] == 'costs_assets_upgrade_cabinet_fttp':
-                    params['costs_assets_upgrade_cabinet_fttp'] = param['default_value']
-                if param['name'] == 'costs_assets_cabinet_fttdp':
-                    params['costs_assets_cabinet_fttdp'] = param['default_value']
-                if param['name'] == 'costs_assets_cabinet_fttc':
-                    params['costs_assets_cabinet_fttc'] = param['default_value']
-                if param['name'] == 'costs_assets_cabinet_adsl':
-                    params['costs_assets_cabinet_adsl'] = param['default_value']
-                if param['name'] == 'costs_assets_premise_fttp_optical_connection_point':
-                    params['costs_assets_premise_fttp_optical_connection_point'] = \
-                        param['default_value']
-                if param['name'] == 'costs_assets_distribution_fttdp_8_ports':
-                    params['costs_assets_distribution_fttdp_8_ports'] = param['default_value']
-                if param['name'] == 'costs_assets_distribution_fttc':
-                    params['costs_assets_distribution_fttc'] = param['default_value']
-                if param['name'] == 'costs_assets_distribution_adsl':
-                    params['costs_assets_distribution_adsl'] = param['default_value']
-                if param['name'] == 'costs_links_fibre_meter':
-                    params['costs_links_fibre_meter'] = param['default_value']
-                if param['name'] == 'costs_links_copper_meter':
-                    params['costs_links_copper_meter'] = param['default_value']
-                if param['name'] == 'costs_assets_premise_fttp_modem':
-                    params['costs_assets_premise_fttp_modem'] = param['default_value']
-                if param['name'] == 'costs_assets_premise_fttp_optical_network_terminator':
-                    params['costs_assets_premise_fttp_optical_network_terminator'] = \
-                        param['default_value']
-                if param['name'] == 'planning_administration_cost':
-                    params['planning_administration_cost'] = param['default_value']
-                if param['name'] == 'costs_assets_premise_fttdp_modem':
-                    params['costs_assets_premise_fttdp_modem'] = param['default_value']
-                if param['name'] == 'costs_assets_premise_fttc_modem':
-                    params['costs_assets_premise_fttc_modem'] = param['default_value']
-                if param['name'] == 'costs_assets_premise_adsl_modem':
-                    params['costs_assets_premise_adsl_modem'] = param['default_value']
-                # revenue aspects
-                if param['name'] == 'months_per_year':
-                    params['months_per_year'] = param['default_value']
-                if param['name'] == 'payback_period':
-                    params['payback_period'] = param['default_value']
-                if param['name'] == 'profit_margin':
-                    params['profit_margin'] = param['default_value']
+            for name, param in parameters.items():
+                parameters[name] = param['default_value']
     return params
 
 ################################################################

--- a/digital_comms/runner.py
+++ b/digital_comms/runner.py
@@ -117,6 +117,7 @@ def read_parameters():
 # LOAD SCENARIO DATA
 ################################################################
 
+
 def load_in_yml_parameters():
     """Load in digital_comms sector model .yml parameter data from
     digital_comms/config/sector_models.

--- a/tests/fixed_network/test_fixed_adoption.py
+++ b/tests/fixed_network/test_fixed_adoption.py
@@ -214,7 +214,7 @@ def test_init_from_data():
     #'distribution_{EACOM}{4}' = 0.3
     #'distribution_{EACOM}{5}' = 0.2
 
-    actual_adoption_year_1 = update_adoption_desirability(system, 40)
+    actual_adoption_year_1 = update_adoption_desirability(system._distributions, 40)
 
     #actual_adoption_year_1 = [
     #('distribution_{EACAM}{3}', True), ('distribution_{EACAM}{2}', True)
@@ -222,7 +222,7 @@ def test_init_from_data():
 
     assert actual_adoption_year_1 == expected_adoption_year_1
 
-    actual_adoption_year_2 = update_adoption_desirability(system, 60)
+    actual_adoption_year_2 = update_adoption_desirability(system._distributions, 60)
 
     #actual_adoption_year_2 = [
     #('distribution_{EACAM}{2}', True)
@@ -230,17 +230,17 @@ def test_init_from_data():
 
     assert actual_adoption_year_2 == expected_adoption_year_2
 
-    actual_adoption_year_3 = update_adoption_desirability(system, 70)
+    actual_adoption_year_3 = update_adoption_desirability(system._distributions, 70)
 
     assert actual_adoption_year_3 == expected_adoption_year_3
 
-    actual_adoption_year_3 = update_adoption_desirability(system, 70)
+    actual_adoption_year_3 = update_adoption_desirability(system._distributions, 70)
 
     #actual_adoption_year_3 = []
 
     assert actual_adoption_year_3 == expected_adoption_year_3
 
-    actual_adoption_year_4 = update_adoption_desirability(system, 80)
+    actual_adoption_year_4 = update_adoption_desirability(system._distributions, 80)
 
     #actual_adoption_year_4 = [
     #('distribution_{EACOM}{4}', True)

--- a/tests/fixed_network/test_fixed_interventions.py
+++ b/tests/fixed_network/test_fixed_interventions.py
@@ -2,7 +2,10 @@ from digital_comms.fixed_network.model import NetworkManager
 from digital_comms.fixed_network.adoption import update_adoption_desirability
 from digital_comms.fixed_network.interventions import decide_interventions
 
-def test_init_from_data():
+from pytest import fixture
+
+
+class TestInitFromData():
     """import decide_interventions and test function.
 
     S1 = FTTP, market_based_roll_out
@@ -13,464 +16,470 @@ def test_init_from_data():
     S6 = FTTdp, outside_in_subsidy
 
     """
-    # setup phase
-    assets = {
-        'distributions':[{
-            'id': 'distribution_{EACAM}{1}',
-            'lad': 'E07000008',
-            'connection': 'cabinet_{EACAM}{P100}',
-            'fttp': 0,
-            'fttdp': 0,
-            'fttc': 5,
-            'docsis3': 5,
-            'adsl': 20,
-            'total_prems': 20,
-            'wta': 0.4,
-            'wtp': 800,
-            'name': 'distribution_{EACAM}{1}',
-            'adoption_desirability': True
-        },
-        {
-            'id': 'distribution_{EACAM}{2}',
-            'lad': 'E07000008',
-            'connection': 'cabinet_{EACAM}{P100}',
-            'fttp': 0,
-            'fttdp': 0,
-            'fttc': 5,
-            'docsis3': 5,
-            'adsl': 20,
-            'total_prems': 20,
-            'wta': 1.0,
-            'wtp': 700,
-            'name': 'distribution_{EACAM}{2}',
-            'adoption_desirability': True
-        },
-        {
-            'id': 'distribution_{EACAM}{3}',
-            'lad': 'E07000008',
-            'connection': 'cabinet_{EACAM}{P100}',
-            'fttp': 0,
-            'fttdp': 0,
-            'fttc': 5,
-            'docsis3': 5,
-            'adsl': 20,
-            'total_prems': 20,
-            'wta': 1.5,
-            'wtp': 600,
-            'name': 'distribution_{EACAM}{3}',
-            'adoption_desirability': True
-        },
-        {
-            'id': 'distribution_{EACOM}{4}',
-            'lad': 'E07000012',
-            'connection': 'cabinet_{EACOM}{P200}',
-            'fttp': 0,
-            'fttdp': 0,
-            'fttc': 5,
-            'docsis3': 5,
-            'adsl': 20,
-            'total_prems': 20,
-            'wta': 0.3,
-            'wtp': 500,
-            'name': 'distribution_{EACOM}{4}',
-            'adoption_desirability': True
-        },
-        {
-            'id': 'distribution_{EACOM}{5}',
-            'lad': 'E07000012',
-            'connection': 'cabinet_{EACOM}{P200}',
-            'fttp': 0,
-            'fttdp': 0,
-            'fttc': 5,
-            'docsis3': 5,
-            'adsl': 20,
-            'total_prems': 20,
-            'wta': 0.2,
-            'wtp': 600,
-            'name': 'distribution_{EACOM}{5}',
-            'adoption_desirability': True
-        }
-        ],
-        'cabinets':[{
-            'id': 'cabinet_{EACAM}{P100}',
-            'connection': 'exchange_EACAM',
-            'fttp': '0',
-            'fttdp': '0',
-            'fttc': '0',
-            'docsis3': '0',
-            'adsl': '1',
-            'name': 'cabinet_{EACAM}{P100}',
-        },
-        {
-            'id': 'cabinet_{EACOM}{P200}',
-            'connection': 'exchange_EACOM',
-            'fttp': '0',
-            'fttdp': '0',
-            'fttc': '0',
-            'docsis3': '0',
-            'adsl': '1',
-            'name': 'cabinet_{EACOM}{P200}',
-        }],
-        'exchanges':[{
-            'id': 'exchange_EACAM',
-            'Name': 'Cambridge',
-            'pcd': '?',
-            'Region': 'East',
-            'County': 'Cambridgeshire',
-            'fttp': '0',
-            'fttdp': '0',
-            'fttc': '0',
-            'docsis3': '0',
-            'adsl': '1',
-        },
-        {
-            'id': 'exchange_EACOM',
-            'Name': 'Cambridge',
-            'pcd': '?',
-            'Region': 'East',
-            'County': 'Cambridgeshire',
-            'fttp': '0',
-            'fttdp': '0',
-            'fttc': '0',
-            'docsis3': '0',
-            'adsl': '1',
-        }]
-    }
 
-    links = [
-        {
-        'origin': 'premises_aggregated',
-        'dest': 'distribution_{EACAM}{1}',
-        'length': 200,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'premises_aggregated',
-        'dest': 'distribution_{EACAM}{2}',
-        'length': 250,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'premises_aggregated',
-        'dest': 'distribution_{EACAM}{3}',
-        'length': 300,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'premises_aggregated',
-        'dest': 'distribution_{EACOM}{4}',
-        'length': 350,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'premises_aggregated',
-        'dest': 'distribution_{EACOM}{5}',
-        'length': 400,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'distribution_{EACAM}{1}',
-        'dest': 'cabinet_{EACAM}{100}',
-        'length': 200,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'distribution_{EACAM}{2}',
-        'dest': 'cabinet_{EACAM}{100}',
-        'length': 250,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'distribution_{EACAM}{3}',
-        'dest': 'cabinet_{EACAM}{100}',
-        'length': 300,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'distribution_{EACOM}{4}',
-        'dest': 'cabinet_{EACOM}{P200}',
-        'length': 350,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'distribution_{EACOM}{5}',
-        'dest': 'cabinet_{EACOM}{P200}',
-        'length': 400,
-        'technology': 'copper'
-        },
-        {
-        'origin': 'cabinet_{EACAM}{P100}',
-        'dest': 'exchange_EACAM',
-        'length': 0,
-        'technology': 'fibre'
-        },
-        {
-        'origin': 'cabinet_{EACOM}{P200}',
-        'dest': 'exchange_EACOM',
-        'length': 0,
-        'technology': 'fibre'
-        },
-    ]
+    @fixture(scope='function')
+    def system(self):
+        """Setup a network manager
+        """
+        assets = {
+            'distributions':[{
+                'id': 'distribution_{EACAM}{1}',
+                'lad': 'E07000008',
+                'connection': 'cabinet_{EACAM}{P100}',
+                'fttp': 0,
+                'fttdp': 0,
+                'fttc': 5,
+                'docsis3': 5,
+                'adsl': 20,
+                'total_prems': 20,
+                'wta': 0.4,
+                'wtp': 800,
+                'name': 'distribution_{EACAM}{1}',
+                'adoption_desirability': True
+            },
+            {
+             'id': 'distribution_{EACAM}{2}',
+             'lad': 'E07000008',
+             'connection': 'cabinet_{EACAM}{P100}',
+             'fttp': 0,
+             'fttdp': 0,
+             'fttc': 5,
+             'docsis3': 5,
+             'adsl': 20,
+             'total_prems': 20,
+             'wta': 1.0,
+             'wtp': 700,
+             'name': 'distribution_{EACAM}{2}',
+             'adoption_desirability': True
+            },
+            {
+             'id': 'distribution_{EACAM}{3}',
+             'lad': 'E07000008',
+             'connection': 'cabinet_{EACAM}{P100}',
+             'fttp': 0,
+             'fttdp': 0,
+             'fttc': 5,
+             'docsis3': 5,
+             'adsl': 20,
+             'total_prems': 20,
+             'wta': 1.5,
+             'wtp': 600,
+             'name': 'distribution_{EACAM}{3}',
+             'adoption_desirability': True
+            },
+            {
+                'id': 'distribution_{EACOM}{4}',
+                'lad': 'E07000012',
+                'connection': 'cabinet_{EACOM}{P200}',
+                'fttp': 0,
+                'fttdp': 0,
+                'fttc': 5,
+                'docsis3': 5,
+                'adsl': 20,
+                'total_prems': 20,
+                'wta': 0.3,
+                'wtp': 500,
+                'name': 'distribution_{EACOM}{4}',
+                'adoption_desirability': True
+            },
+            {
+                'id': 'distribution_{EACOM}{5}',
+                'lad': 'E07000012',
+                'connection': 'cabinet_{EACOM}{P200}',
+                'fttp': 0,
+                'fttdp': 0,
+                'fttc': 5,
+                'docsis3': 5,
+                'adsl': 20,
+                'total_prems': 20,
+                'wta': 0.2,
+                'wtp': 600,
+                'name': 'distribution_{EACOM}{5}',
+                'adoption_desirability': True
+            }
+            ],
+            'cabinets':[{
+                'id': 'cabinet_{EACAM}{P100}',
+                'connection': 'exchange_EACAM',
+                'fttp': '0',
+                'fttdp': '0',
+                'fttc': '0',
+                'docsis3': '0',
+                'adsl': '1',
+                'name': 'cabinet_{EACAM}{P100}',
+            },
+            {
+                'id': 'cabinet_{EACOM}{P200}',
+                'connection': 'exchange_EACOM',
+                'fttp': '0',
+                'fttdp': '0',
+                'fttc': '0',
+                'docsis3': '0',
+                'adsl': '1',
+                'name': 'cabinet_{EACOM}{P200}',
+            }],
+            'exchanges':[{
+                'id': 'exchange_EACAM',
+                'Name': 'Cambridge',
+                'pcd': '?',
+                'Region': 'East',
+                'County': 'Cambridgeshire',
+                'fttp': '0',
+                'fttdp': '0',
+                'fttc': '0',
+                'docsis3': '0',
+                'adsl': '1',
+            },
+            {
+                'id': 'exchange_EACOM',
+                'Name': 'Cambridge',
+                'pcd': '?',
+                'Region': 'East',
+                'County': 'Cambridgeshire',
+                'fttp': '0',
+                'fttdp': '0',
+                'fttc': '0',
+                'docsis3': '0',
+                'adsl': '1',
+            }]
+            }
 
-    parameters = {
-        'costs_links_fibre_meter': 5,
-        'costs_links_copper_meter': 3,
-        'costs_assets_exchange_fttp': 50000,
-        'costs_assets_exchange_fttc': 30000,
-        'costs_assets_exchange_fttdp': 25000,
-        'costs_assets_exchange_adsl': 20000,
-        'costs_assets_cabinet_fttp_32_ports': 10,
-        'costs_assets_cabinet_fttdp': 4000,
-        'costs_assets_cabinet_fttc': 3000,
-        'costs_assets_cabinet_fttdp': 2500,
-        'costs_assets_cabinet_adsl': 2000,
-        'costs_assets_distribution_fttp_32_ports': 10,
-        'costs_assets_distribution_fttdp_4_ports': 1500,
-        'costs_assets_distribution_fttc': 300,
-        'costs_assets_distribution_fttdp_8_ports': 250,
-        'costs_assets_distribution_adsl': 200,
-        'costs_assets_premise_fttp_modem': 20,
-        'costs_assets_premise_fttp_optical_network_terminator': 10,
-        'costs_assets_premise_fttp_optical_connection_point': 37,
-        'costs_assets_premise_fttdp_modem': 20,
-        'costs_assets_premise_fttc_modem': 15,
-        'costs_assets_premise_fttdp_modem': 12,
-        'costs_assets_premise_adsl_modem': 10,
-        'benefits_assets_premise_fttp': 50,
-        'benefits_assets_premise_fttdp': 40,
-        'benefits_assets_premise_fttc': 30,
-        'benefits_assets_premise_adsl': 20,
-        'planning_administration_cost': 10,
-    }
+        links = [
+                {
+                'origin': 'premises_aggregated',
+                'dest': 'distribution_{EACAM}{1}',
+                'length': 200,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'premises_aggregated',
+                'dest': 'distribution_{EACAM}{2}',
+                'length': 250,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'premises_aggregated',
+                'dest': 'distribution_{EACAM}{3}',
+                'length': 300,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'premises_aggregated',
+                'dest': 'distribution_{EACOM}{4}',
+                'length': 350,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'premises_aggregated',
+                'dest': 'distribution_{EACOM}{5}',
+                'length': 400,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'distribution_{EACAM}{1}',
+                'dest': 'cabinet_{EACAM}{100}',
+                'length': 200,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'distribution_{EACAM}{2}',
+                'dest': 'cabinet_{EACAM}{100}',
+                'length': 250,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'distribution_{EACAM}{3}',
+                'dest': 'cabinet_{EACAM}{100}',
+                'length': 300,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'distribution_{EACOM}{4}',
+                'dest': 'cabinet_{EACOM}{P200}',
+                'length': 350,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'distribution_{EACOM}{5}',
+                'dest': 'cabinet_{EACOM}{P200}',
+                'length': 400,
+                'technology': 'copper'
+                },
+                {
+                'origin': 'cabinet_{EACAM}{P100}',
+                'dest': 'exchange_EACAM',
+                'length': 0,
+                'technology': 'fibre'
+                },
+                {
+                'origin': 'cabinet_{EACOM}{P200}',
+                'dest': 'exchange_EACOM',
+                'length': 0,
+                'technology': 'fibre'
+                },
+            ]
 
-    #####################################################
-    #TEST S1 FTTP
-    #####################################################
+        parameters = {
+                'costs_links_fibre_meter': 5,
+                'costs_links_copper_meter': 3,
+                'costs_assets_exchange_fttp': 50000,
+                'costs_assets_exchange_fttc': 30000,
+                'costs_assets_exchange_fttdp': 25000,
+                'costs_assets_exchange_adsl': 20000,
+                'costs_assets_cabinet_fttp_32_ports': 10,
+                'costs_assets_cabinet_fttdp': 4000,
+                'costs_assets_cabinet_fttc': 3000,
+                'costs_assets_cabinet_fttdp': 2500,
+                'costs_assets_cabinet_adsl': 2000,
+                'costs_assets_distribution_fttp_32_ports': 10,
+                'costs_assets_distribution_fttdp_4_ports': 1500,
+                'costs_assets_distribution_fttc': 300,
+                'costs_assets_distribution_fttdp_8_ports': 250,
+                'costs_assets_distribution_adsl': 200,
+                'costs_assets_premise_fttp_modem': 20,
+                'costs_assets_premise_fttp_optical_network_terminator': 10,
+                'costs_assets_premise_fttp_optical_connection_point': 37,
+                'costs_assets_premise_fttdp_modem': 20,
+                'costs_assets_premise_fttc_modem': 15,
+                'costs_assets_premise_fttdp_modem': 12,
+                'costs_assets_premise_adsl_modem': 10,
+                'benefits_assets_premise_fttp': 50,
+                'benefits_assets_premise_fttdp': 40,
+                'benefits_assets_premise_fttc': 30,
+                'benefits_assets_premise_adsl': 20,
+                'planning_administration_cost': 10,
+            }
+        return NetworkManager(assets, links, parameters)
 
-    year = 2019
-    technology = 'fttp'
-    policy = 's1_market_based_roll_out'
-    annual_budget = 2000
-    adoption_cap = 40
-    subsidy = 2000
-    telco_match_funding = 2000
-    service_obligation_capacity = 10
+    def test_s1_fttp(self, system):
+        #####################################################
+        # TEST S1 FTTP
+        #####################################################
 
-    s1_expected_built_interventions = [
-        ('distribution_{EACAM}{1}', 'fttp', 's1_market_based_roll_out', 'market_based', 1837)
-    ]
+        year = 2019
+        technology = 'fttp'
+        policy = 's1_market_based_roll_out'
+        annual_budget = 2000
+        adoption_cap = 40
+        subsidy = 2000
+        telco_match_funding = 2000
+        service_obligation_capacity = 10
 
-    system = NetworkManager(assets, links, parameters)
-
-    #40% want to adopt in total
-    distribution_adoption_desirability_ids = update_adoption_desirability(system._distributions, 40)
-
-    #update model adoption desirability
-    system.update_adoption_desirability(distribution_adoption_desirability_ids)
-
-    #Total cost should be £1837
-    #fttp modem: £20 * 20 = £400
-    #optical network terminal: £10 * 20 = £200
-    #planning cost: £10 * 20 = £200
-    #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    #fibre upgrade cost: £5 * 200 = 1000
-
-    #build interventions
-    s1_built_interventions = decide_interventions(
-        system, year, technology, policy, annual_budget, adoption_cap,
-        subsidy, telco_match_funding, service_obligation_capacity)
-
-    assert s1_built_interventions == s1_expected_built_interventions
-
-
-    #####################################################
-    #TEST S2 FTTP
-    #####################################################
-
-    year = 2019
-    technology = 'fttp'
-    policy = 's2_rural_based_subsidy'
-    annual_budget = 2500
-    adoption_cap = 40
-    subsidy = 2500
-    telco_match_funding = 2500
-    service_obligation_capacity = 10
-
-    s2_expected_built_interventions = [
-        ('distribution_{EACAM}{1}', 'fttp', 's2_rural_based_subsidy', 'market_based', 1837),
-        ('distribution_{EACAM}{2}', 'fttp', 's2_rural_based_subsidy', 'subsidy_based', 2087)
+        s1_expected_built_interventions = [
+            ('distribution_{EACAM}{1}', 'fttp', 's1_market_based_roll_out', 'market_based', 1837)
         ]
 
-    #Total cost should be £1837
-    #fttp modem: £20 * 20 = £400
-    #optical network terminal: £10 * 20 = £200
-    #planning cost: £10 * 20 = £200
-    #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    #fibre upgrade cost: £5 * 200 = 1000
+        # 40% want to adopt in total
+        distribution_adoption_desirability_ids = update_adoption_desirability(system._distributions, 40)
 
-    #Total cost should be 2087
-    #fttp modem: £20 * 20 = £400
-    #optical network terminal: £10 * 20 = £200
-    #planning cost: £10 * 20 = £200
-    #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    #fibre upgrade cost: £5 * 250 = 1250
+        # update model adoption desirability
+        system.update_adoption_desirability(distribution_adoption_desirability_ids)
 
-    #build interventions
-    s2_built_interventions = decide_interventions(
-        system, year, technology, policy, annual_budget, adoption_cap,
-        subsidy, telco_match_funding, service_obligation_capacity)
+        # Total cost should be £1837
+        # fttp modem: £20 * 20 = £400
+        # optical network terminal: £10 * 20 = £200
+        # planning cost: £10 * 20 = £200
+        # optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        # fibre upgrade cost: £5 * 200 = 1000
 
-    assert s2_built_interventions == s2_expected_built_interventions
+        # build interventions
+        s1_built_interventions = decide_interventions(
+            system._distributions, year, technology, policy, annual_budget, adoption_cap,
+            subsidy, telco_match_funding, service_obligation_capacity)
 
-    #####################################################
-    #TEST S3 FTTP
-    #####################################################
+        assert s1_built_interventions == s1_expected_built_interventions
 
-    year = 2019
-    technology = 'fttp'
-    policy = 's3_outside_in_subsidy'
-    annual_budget = 4000
-    adoption_cap = 40
-    subsidy = 4000
-    telco_match_funding = 4000
-    service_obligation_capacity = 10
+    def test_s2_fttp(self, system):
+        #####################################################
+        # TEST S2 FTTP
+        #####################################################
+        year = 2019
+        technology = 'fttp'
+        policy = 's2_rural_based_subsidy'
+        annual_budget = 2500
+        adoption_cap = 40
+        subsidy = 2500
+        telco_match_funding = 2500
+        service_obligation_capacity = 10
 
-    s3_expected_built_interventions = [
-        ('distribution_{EACAM}{1}', 'fttp', 's3_outside_in_subsidy', 'market_based', 1837),
-        ('distribution_{EACOM}{5}', 'fttp', 's3_outside_in_subsidy', 'subsidy_based', 2837)
-        ]
+        s2_expected_built_interventions = [
+            ('distribution_{EACAM}{1}', 'fttp', 's2_rural_based_subsidy', 'market_based', 1837),
+            ('distribution_{EACAM}{2}', 'fttp', 's2_rural_based_subsidy', 'subsidy_based', 2087)
+            ]
 
-    #Total cost should be £1837
-    #fttp modem: £20 * 20 = £400
-    #optical network terminal: £10 * 20 = £200
-    #planning cost: £10 * 20 = £200
-    #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    #fibre upgrade cost: £5 * 200 = 1000
+        #Total cost should be £1837
+        #fttp modem: £20 * 20 = £400
+        #optical network terminal: £10 * 20 = £200
+        #planning cost: £10 * 20 = £200
+        #optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        #fibre upgrade cost: £5 * 200 = 1000
 
-    #Total cost should be 2837
-    #fttp modem: £20 * 20 = £400
-    #optical network terminal: £10 * 20 = £200
-    #planning cost: £10 * 20 = £200
-    #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    #fibre upgrade cost: £5 * 400 = 2000
+        #Total cost should be 2087
+        #fttp modem: £20 * 20 = £400
+        #optical network terminal: £10 * 20 = £200
+        #planning cost: £10 * 20 = £200
+        #optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        #fibre upgrade cost: £5 * 250 = 1250
 
-    #build interventions
-    s3_built_interventions = decide_interventions(
-        system, year, technology, policy, annual_budget, adoption_cap,
-        subsidy, telco_match_funding, service_obligation_capacity)
+        #build interventions
+        s2_built_interventions = decide_interventions(
+            system._distributions, year, technology, policy, annual_budget, adoption_cap,
+            subsidy, telco_match_funding, service_obligation_capacity)
 
-    assert s3_built_interventions == s3_expected_built_interventions
+        assert s2_built_interventions == s2_expected_built_interventions
 
-    # #####################################################
-    # #TEST S4 FTTdp
-    # #####################################################
+    def test_s3_fttp(self, system):
+        #####################################################
+        # TEST S3 FTTP
+        #####################################################
+        year = 2019
+        technology = 'fttp'
+        policy = 's3_outside_in_subsidy'
+        annual_budget = 4000
+        adoption_cap = 40
+        subsidy = 4000
+        telco_match_funding = 4000
+        service_obligation_capacity = 10
 
-    # year = 2019
-    # technology = 'fttdp'
-    # policy = 's1_market_based_roll_out'
-    # annual_budget = 2000
-    # adoption_cap = 40
-    # subsidy = 2000
-    # telco_match_funding = 2000
-    # service_obligation_capacity = 10
+        s3_expected_built_interventions = [
+            ('distribution_{EACAM}{1}', 'fttp', 's3_outside_in_subsidy', 'market_based', 1837),
+            ('distribution_{EACOM}{5}', 'fttp', 's3_outside_in_subsidy', 'subsidy_based', 2837)
+            ]
 
-    # s4_expected_built_interventions = [
-    #     ('distribution_{EACAM}{1}', 'fttdp', 's1_market_based_roll_out', 'market_based', 1837)
-    # ]
+        # Total cost should be £1837
+        # fttp modem: £20 * 20 = £400
+        # optical network terminal: £10 * 20 = £200
+        # planning cost: £10 * 20 = £200
+        # optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        # fibre upgrade cost: £5 * 200 = 1000
 
-    # system = NetworkManager(assets, links, parameters)
+        # Total cost should be 2837
+        # fttp modem: £20 * 20 = £400
+        # optical network terminal: £10 * 20 = £200
+        # planning cost: £10 * 20 = £200
+        # optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        # fibre upgrade cost: £5 * 400 = 2000
 
-    # #40% want to adopt in total
-    # distribution_adoption_desirability_ids = update_adoption_desirability(system, 40)
+        # build interventions
+        s3_built_interventions = decide_interventions(
+            system._distributions, year, technology, policy, annual_budget, adoption_cap,
+            subsidy, telco_match_funding, service_obligation_capacity)
 
-    # #update model adoption desirability
-    # system.update_adoption_desirability(distribution_adoption_desirability_ids)
+        assert s3_built_interventions == s3_expected_built_interventions
 
-    # #Total cost should be £1150
-    # #fttdp modem: £20 * 20 = £400
-    # #costs_assets_distribution_fttdp_8_ports: £250 * 3 = £750
+    # def test_s4_fttdp(self, system):
+        #####################################################
+        #TEST S4 FTTdp
+        #####################################################
 
-    # #build interventions
-    # s4_built_interventions = decide_interventions(
-    #     system, year, technology, policy, annual_budget, adoption_cap,
-    #     subsidy, telco_match_funding, service_obligation_capacity)
+        # year = 2019
+        # technology = 'fttdp'
+        # policy = 's1_market_based_roll_out'
+        # annual_budget = 2000
+        # adoption_cap = 40
+        # subsidy = 2000
+        # telco_match_funding = 2000
+        # service_obligation_capacity = 10
 
-    # assert s4_built_interventions == s4_expected_built_interventions
+        # s4_expected_built_interventions = [
+        #     ('distribution_{EACAM}{1}', 'fttdp', 's1_market_based_roll_out', 'market_based', 1837)
+        # ]
 
-    # #####################################################
-    # #TEST S2 FTTdp
-    # #####################################################
+        # system = NetworkManager(assets, links, parameters)
 
-    # year = 2019
-    # technology = 'fttp'
-    # policy = 's2_rural_based_subsidy'
-    # annual_budget = 2500
-    # adoption_cap = 40
-    # subsidy = 2500
-    # telco_match_funding = 2500
-    # service_obligation_capacity = 10
+        # #40% want to adopt in total
+        # distribution_adoption_desirability_ids = update_adoption_desirability(system, 40)
 
-    # s2_expected_built_interventions = [
-    #     ('distribution_{EACAM}{1}', 'fttp', 's2_rural_based_subsidy', 'market_based', 1837),
-    #     ('distribution_{EACAM}{2}', 'fttp', 's2_rural_based_subsidy', 'subsidy_based', 2087)
-    #     ]
+        # #update model adoption desirability
+        # system.update_adoption_desirability(distribution_adoption_desirability_ids)
 
-    # #Total cost should be £1837
-    # #fttp modem: £20 * 20 = £400
-    # #optical network terminal: £10 * 20 = £200
-    # #planning cost: £10 * 20 = £200
-    # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    # #fibre upgrade cost: £5 * 200 = 1000
+        # #Total cost should be £1150
+        # #fttdp modem: £20 * 20 = £400
+        # #costs_assets_distribution_fttdp_8_ports: £250 * 3 = £750
 
-    # #Total cost should be 2087
-    # #fttp modem: £20 * 20 = £400
-    # #optical network terminal: £10 * 20 = £200
-    # #planning cost: £10 * 20 = £200
-    # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    # #fibre upgrade cost: £5 * 250 = 1250
+        # #build interventions
+        # s4_built_interventions = decide_interventions(
+        #     system, year, technology, policy, annual_budget, adoption_cap,
+        #     subsidy, telco_match_funding, service_obligation_capacity)
 
-    # #build interventions
-    # s2_built_interventions = decide_interventions(
-    #     system, year, technology, policy, annual_budget, adoption_cap,
-    #     subsidy, telco_match_funding, service_obligation_capacity)
+        # assert s4_built_interventions == s4_expected_built_interventions
 
-    # assert s2_built_interventions == s2_expected_built_interventions
+    # def test_s2_fttdp(self, system):
+        # #####################################################
+        # #TEST S2 FTTdp
+        # #####################################################
 
-    # #####################################################
-    # #TEST S3 FTTdp
-    # #####################################################
+        # year = 2019
+        # technology = 'fttp'
+        # policy = 's2_rural_based_subsidy'
+        # annual_budget = 2500
+        # adoption_cap = 40
+        # subsidy = 2500
+        # telco_match_funding = 2500
+        # service_obligation_capacity = 10
 
-    # year = 2019
-    # technology = 'fttp'
-    # policy = 's3_outside_in_subsidy'
-    # annual_budget = 4000
-    # adoption_cap = 40
-    # subsidy = 4000
-    # telco_match_funding = 4000
-    # service_obligation_capacity = 10
+        # s2_expected_built_interventions = [
+        #     ('distribution_{EACAM}{1}', 'fttp', 's2_rural_based_subsidy', 'market_based', 1837),
+        #     ('distribution_{EACAM}{2}', 'fttp', 's2_rural_based_subsidy', 'subsidy_based', 2087)
+        #     ]
 
-    # s3_expected_built_interventions = [
-    #     ('distribution_{EACAM}{1}', 'fttp', 's3_outside_in_subsidy', 'market_based', 1837),
-    #     ('distribution_{EACOM}{5}', 'fttp', 's3_outside_in_subsidy', 'subsidy_based', 2837)
-    #     ]
+        # #Total cost should be £1837
+        # #fttp modem: £20 * 20 = £400
+        # #optical network terminal: £10 * 20 = £200
+        # #planning cost: £10 * 20 = £200
+        # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        # #fibre upgrade cost: £5 * 200 = 1000
 
-    # #Total cost should be £1837
-    # #fttp modem: £20 * 20 = £400
-    # #optical network terminal: £10 * 20 = £200
-    # #planning cost: £10 * 20 = £200
-    # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    # #fibre upgrade cost: £5 * 200 = 1000
+        # #Total cost should be 2087
+        # #fttp modem: £20 * 20 = £400
+        # #optical network terminal: £10 * 20 = £200
+        # #planning cost: £10 * 20 = £200
+        # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        # #fibre upgrade cost: £5 * 250 = 1250
 
-    # #Total cost should be 2837
-    # #fttp modem: £20 * 20 = £400
-    # #optical network terminal: £10 * 20 = £200
-    # #planning cost: £10 * 20 = £200
-    # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
-    # #fibre upgrade cost: £5 * 400 = 2000
+        # #build interventions
+        # s2_built_interventions = decide_interventions(
+        #     system, year, technology, policy, annual_budget, adoption_cap,
+        #     subsidy, telco_match_funding, service_obligation_capacity)
 
-    # #build interventions
-    # s3_built_interventions = decide_interventions(
-    #     system, year, technology, policy, annual_budget, adoption_cap,
-    #     subsidy, telco_match_funding, service_obligation_capacity)
+        # assert s2_built_interventions == s2_expected_built_interventions
 
-    # assert s3_built_interventions == s3_expected_built_interventions
+    # def test_d3fttdp(self, system):
+        # #####################################################
+        # #TEST S3 FTTdp
+        # #####################################################
+
+        # year = 2019
+        # technology = 'fttp'
+        # policy = 's3_outside_in_subsidy'
+        # annual_budget = 4000
+        # adoption_cap = 40
+        # subsidy = 4000
+        # telco_match_funding = 4000
+        # service_obligation_capacity = 10
+
+        # s3_expected_built_interventions = [
+        #     ('distribution_{EACAM}{1}', 'fttp', 's3_outside_in_subsidy', 'market_based', 1837),
+        #     ('distribution_{EACOM}{5}', 'fttp', 's3_outside_in_subsidy', 'subsidy_based', 2837)
+        #     ]
+
+        # #Total cost should be £1837
+        # #fttp modem: £20 * 20 = £400
+        # #optical network terminal: £10 * 20 = £200
+        # #planning cost: £10 * 20 = £200
+        # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        # #fibre upgrade cost: £5 * 200 = 1000
+
+        # #Total cost should be 2837
+        # #fttp modem: £20 * 20 = £400
+        # #optical network terminal: £10 * 20 = £200
+        # #planning cost: £10 * 20 = £200
+        # #optical connection point: £37 * 1 = £37 (32 premises per connection point)
+        # #fibre upgrade cost: £5 * 400 = 2000
+
+        # #build interventions
+        # s3_built_interventions = decide_interventions(
+        #     system, year, technology, policy, annual_budget, adoption_cap,
+        #     subsidy, telco_match_funding, service_obligation_capacity)
+
+        # assert s3_built_interventions == s3_expected_built_interventions

--- a/tests/fixed_network/test_fixed_interventions.py
+++ b/tests/fixed_network/test_fixed_interventions.py
@@ -263,7 +263,7 @@ def test_init_from_data():
     system = NetworkManager(assets, links, parameters)
 
     #40% want to adopt in total
-    distribution_adoption_desirability_ids = update_adoption_desirability(system, 40)
+    distribution_adoption_desirability_ids = update_adoption_desirability(system._distributions, 40)
 
     #update model adoption desirability
     system.update_adoption_desirability(distribution_adoption_desirability_ids)


### PR DESCRIPTION
- Adds `data_path` arguments to the functions which read in assets and links using read_csv. This allows these functions to be imported and re-used from `nismod2/models/digital_comms/run.py` 
- Commit 6643d1e simplifies `read_parameters` which @edwardoughton, you should check before accepting.  You can `git revert 6643d1e` to undo this commit if it is not helpful.

- Closes #82 
  - We now pass a list of distribution objects into the various methods in interventions.py and adoption.py rather than a system object. This will allow the decision module (which won't have access to the system object) to use these methods.
  - ~~I also demonstrate how to use test classes and a pytest fixture to setup a system for each of the tests.  This is a really useful way to organise the tests and makes it easier to find and fix the bugs. You'll note that the tests now pass `system._distributions` into the methods whose arguments have changed. The tests make making these sorts of changes really easy to check!~~
  - I have merged in your changes to the test from master to my branch, which makes to above defunct!