### PR TITLE
Fixed network refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+python: 3.6
 virtualenv:
   system_site_packages: true
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: python
-python: 3.6
-virtualenv:
-  system_site_packages: true
+python:
+- "3.6"
 env:
   matrix:
   - DISTRIB="conda" COVERAGE="true"

--- a/digital_comms/fixed_network/adoption.py
+++ b/digital_comms/fixed_network/adoption.py
@@ -7,7 +7,7 @@ from logging import getLogger
 LOGGER = getLogger(__name__)
 
 
-def update_adoption_desirability(distributions, annual_adoption_rate, technology):
+def update_adoption_desirability(distributions, annual_adoption_rate):
     """
     Given adoption parameters and a set of distribution points, return likely adoptees.
 

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -448,6 +448,7 @@ class Asset(metaclass=ABCMeta):
     """
 
     def __init__(self, clients=None):
+        self.id = None
         if clients:
             self._clients = clients
         else:
@@ -865,7 +866,10 @@ class Distribution(Asset):
 
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
             if self.adoption_desirability:
-                rollout_benefits[tech] = benefit
+                if getattr(self, tech) == 0:
+                    rollout_benefits[tech] = benefit
+                else:
+                    rollout_benefits[tech] = 0
             else:
                 rollout_benefits[tech] = 0
         return rollout_benefits

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -472,25 +472,21 @@ class Asset(metaclass=ABCMeta):
     def upgrade(self, action):
         """Upgrade the asset's clients with an ``action``
 
+        If a leaf asset (e.g. a distribution point with no clients), upgrade
+        self.
+
         Arguments
         ---------
         action : str
         """
         if self._clients:
-            if action == 'fttp':
-                if self.link is not None:
-                    self.link.upgrade('fibre')
-                for client in self._clients:
-                    client.upgrade(action)
+            if self.link is not None:
+                self.link.upgrade('fibre')
+            for client in self._clients:
+                client.upgrade(action)
 
-            if action == 'fttdp':
-                if self.link is not None:
-                    self.link.upgrade('fibre')
-                for client in self._clients:
-                    client.upgrade(action)
         else:
             if action in ('fttp'):
-                action = 'fttp'
                 self._fttp = self.total_prems
                 self._fttdp = 0
                 self._fttc = 0
@@ -499,8 +495,7 @@ class Asset(metaclass=ABCMeta):
                 if self.link is not None:
                     self.link.upgrade('fibre')
 
-            if action in ('fttdp'):
-                action = 'fttdp'
+            elif action in ('fttdp'):
                 self._fttdp = self.total_prems
                 self._fttc = 0
                 self._docsis3 = 0

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -447,32 +447,26 @@ class Asset(metaclass=ABCMeta):
         return NotImplementedError
 
     @property
-    @lru_cache(maxsize=4096)
     def fttp(self):
         return sum([client.fttp for client in self._clients])
 
     @property
-    @lru_cache(maxsize=4096)
     def fttdp(self):
         return sum([client.fttdp for client in self._clients])
 
     @property
-    @lru_cache(maxsize=4096)
     def fttc(self):
         return sum([client.fttc for client in self._clients])
 
     @property
-    @lru_cache(maxsize=4096)
     def docsis3(self):
         return sum([client.docsis3 for client in self._clients])
 
     @property
-    @lru_cache(maxsize=4096)
     def adsl(self):
         return sum([client.adsl for client in self._clients])
 
     @property
-    @lru_cache(maxsize=4096)
     def total_prems(self):
         return sum([client.total_prems for client in self._clients])
 
@@ -511,7 +505,6 @@ class Asset(metaclass=ABCMeta):
         self.compute()
 
     @property
-    @lru_cache(maxsize=4096)
     def rollout_costs(self):
         rollout_costs = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -520,7 +513,6 @@ class Asset(metaclass=ABCMeta):
         return rollout_costs
 
     @property
-    @lru_cache(maxsize=4096)
     def rollout_benefits(self):
         rollout_benefits = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -529,7 +521,6 @@ class Asset(metaclass=ABCMeta):
         return rollout_benefits
 
     @property
-    @lru_cache(maxsize=4096)
     def rollout_bcr(self):
         rollout_bcr = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -538,7 +529,6 @@ class Asset(metaclass=ABCMeta):
         return rollout_bcr
 
     @property
-    @lru_cache(maxsize=4096)
     def total_potential_benefit(self):
         total_potential_benefit = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -547,7 +537,6 @@ class Asset(metaclass=ABCMeta):
         return total_potential_benefit
 
     @property
-    @lru_cache(maxsize=4096)
     def total_potential_bcr(self):
         total_potential_bcr = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -844,7 +833,6 @@ class Distribution(Asset):
         return upgrade_costs
 
     @property
-    @lru_cache(maxsize=4096)
     def rollout_benefits(self):
         """Compute the benefit of rolling out the technologies
 
@@ -860,23 +848,23 @@ class Distribution(Asset):
         rollout_benefits = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
             if self.adoption_desirability:
-                rollout_benefits[tech] = _calculate_potential_revenue(
-                    self.wtp, self.parameters['months_per_year'],
-                    self.parameters['payback_period'], self.parameters['profit_margin'])
+                rollout_benefits[tech] = self._calculate_revenue(tech)
             else:
                 rollout_benefits[tech] = 0
         return rollout_benefits
 
     @property
-    @lru_cache(maxsize=4096)
     def total_potential_benefit(self):
         total_potential_benefit = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
-            total_potential_benefit[tech] = _calculate_potential_revenue(
-                self.wtp, self.parameters['months_per_year'],
-                self.parameters['payback_period'], self.parameters['profit_margin']
-            )
+            total_potential_benefit[tech] = self._calculate_revenue(tech)
         return total_potential_benefit
+
+    def _calculate_revenue(self, tech):
+        return _calculate_potential_revenue(
+                self.wtp, self.parameters['months_per_year'],
+                self.parameters['payback_period'],
+                self.parameters['profit_margin'])
 
     def connection_capacity(self, technology):
         capacity = _generic_connection_capacity(technology)

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -859,12 +859,12 @@ class Distribution(Asset):
         """
         rollout_benefits = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
-            # if self.adoption_desirability:
-            rollout_benefits[tech] = _calculate_potential_revenue(
-                self.wtp, self.parameters['months_per_year'],
-                self.parameters['payback_period'], self.parameters['profit_margin'])
-            # else:
-            #     rollout_benefits[tech] = 0
+            if self.adoption_desirability:
+                rollout_benefits[tech] = _calculate_potential_revenue(
+                    self.wtp, self.parameters['months_per_year'],
+                    self.parameters['payback_period'], self.parameters['profit_margin'])
+            else:
+                rollout_benefits[tech] = 0
         return rollout_benefits
 
     @property

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 from math import ceil
 from abc import abstractmethod, abstractproperty, ABCMeta
+from functools import lru_cache
 
 #####################
 # MODEL
@@ -446,26 +447,32 @@ class Asset(metaclass=ABCMeta):
         return NotImplementedError
 
     @property
+    @lru_cache(maxsize=4096)
     def fttp(self):
         return sum([client.fttp for client in self._clients])
 
     @property
+    @lru_cache(maxsize=4096)
     def fttdp(self):
         return sum([client.fttdp for client in self._clients])
 
     @property
+    @lru_cache(maxsize=4096)
     def fttc(self):
         return sum([client.fttc for client in self._clients])
 
     @property
+    @lru_cache(maxsize=4096)
     def docsis3(self):
         return sum([client.docsis3 for client in self._clients])
 
     @property
+    @lru_cache(maxsize=4096)
     def adsl(self):
         return sum([client.adsl for client in self._clients])
 
     @property
+    @lru_cache(maxsize=4096)
     def total_prems(self):
         return sum([client.total_prems for client in self._clients])
 
@@ -504,6 +511,7 @@ class Asset(metaclass=ABCMeta):
         self.compute()
 
     @property
+    @lru_cache(maxsize=4096)
     def rollout_costs(self):
         rollout_costs = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -512,6 +520,7 @@ class Asset(metaclass=ABCMeta):
         return rollout_costs
 
     @property
+    @lru_cache(maxsize=4096)
     def rollout_benefits(self):
         rollout_benefits = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -520,6 +529,7 @@ class Asset(metaclass=ABCMeta):
         return rollout_benefits
 
     @property
+    @lru_cache(maxsize=4096)
     def rollout_bcr(self):
         rollout_bcr = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -528,6 +538,7 @@ class Asset(metaclass=ABCMeta):
         return rollout_bcr
 
     @property
+    @lru_cache(maxsize=4096)
     def total_potential_benefit(self):
         total_potential_benefit = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -536,6 +547,7 @@ class Asset(metaclass=ABCMeta):
         return total_potential_benefit
 
     @property
+    @lru_cache(maxsize=4096)
     def total_potential_bcr(self):
         total_potential_bcr = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
@@ -729,29 +741,6 @@ class Distribution(Asset):
         TODO
     parameters : dict
         Contains all parameters from 'digital_comms.yml'.
-
-    Attributes
-    ----------
-    id
-    connection
-    fttp
-    fttdp
-    fttc
-    adsl
-    wta
-    wtp
-    adoption_desirability
-    parameters
-    link
-    compute()
-
-    Methods
-    -------
-    compute
-        Calculates upgrade costs and benefits.
-    upgrade
-        Upgrades any links with new technology.
-
     """
     def __init__(self, data, link, parameters):
         super().__init__()
@@ -854,10 +843,10 @@ class Distribution(Asset):
         )
         return upgrade_costs
 
-
     @property
+    @lru_cache(maxsize=4096)
     def rollout_benefits(self):
-        """
+        """Compute the benefit of rolling out the technologies
 
         Notes
         -----
@@ -870,15 +859,16 @@ class Distribution(Asset):
         """
         rollout_benefits = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
-            if self.adoption_desirability:
-                rollout_benefits[tech] = _calculate_potential_revenue(
-                    self.wtp, self.parameters['months_per_year'],
-                    self.parameters['payback_period'], self.parameters['profit_margin'])
-            else:
-                rollout_benefits[tech] = 0
+            # if self.adoption_desirability:
+            rollout_benefits[tech] = _calculate_potential_revenue(
+                self.wtp, self.parameters['months_per_year'],
+                self.parameters['payback_period'], self.parameters['profit_margin'])
+            # else:
+            #     rollout_benefits[tech] = 0
         return rollout_benefits
 
     @property
+    @lru_cache(maxsize=4096)
     def total_potential_benefit(self):
         total_potential_benefit = {}
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -815,18 +815,18 @@ class Distribution(Asset):
         upgrade_costs = {}
         upgrade_costs['fttp'] = (
             (self.parameters['costs_assets_premise_fttp_modem'] * self.total_prems) +
-            (self.parameters['costs_assets_premise_fttp_optical_network_terminator'] \
+            (self.parameters['costs_assets_premise_fttp_optical_network_terminator']
                 * self.total_prems if self.fttp == 0 else 0) +
-            (self.parameters['planning_administration_cost'] * self.total_prems \
+            (self.parameters['planning_administration_cost'] * self.total_prems
                 if self.fttp == 0 else 0) +
-            (self.parameters['costs_assets_premise_fttp_optical_connection_point'] \
+            (self.parameters['costs_assets_premise_fttp_optical_connection_point']
                 * (-(-self.total_prems // 32))) +
             (self.link.upgrade_costs['fibre'] if self.link is not None else 0)
         )
         upgrade_costs['fttdp'] = (
-            (self.parameters['costs_assets_distribution_fttdp_8_ports'] \
+            (self.parameters['costs_assets_distribution_fttdp_8_ports']
                 * (-(-self.total_prems // 8)) if self.fttdp == 0 else 0) +
-            (self.parameters['costs_assets_premise_fttdp_modem'] * self.total_prems \
+            (self.parameters['costs_assets_premise_fttdp_modem'] * self.total_prems
                 if self.fttdp == 0 else 0)
         )
         upgrade_costs['fttc'] = (
@@ -855,9 +855,12 @@ class Distribution(Asset):
 
         """
         rollout_benefits = {}
+
+        benefit = self._calculate_revenue()
+
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
             if self.adoption_desirability:
-                rollout_benefits[tech] = self._calculate_revenue(tech)
+                rollout_benefits[tech] = benefit
             else:
                 rollout_benefits[tech] = 0
         return rollout_benefits
@@ -865,11 +868,14 @@ class Distribution(Asset):
     @property
     def total_potential_benefit(self):
         total_potential_benefit = {}
+
+        benefit = self._calculate_revenue()
+
         for tech in ['fttp', 'fttdp', 'fttc', 'adsl']:
-            total_potential_benefit[tech] = self._calculate_revenue(tech)
+            total_potential_benefit[tech] = benefit
         return total_potential_benefit
 
-    def _calculate_revenue(self, tech):
+    def _calculate_revenue(self):
         return _calculate_potential_revenue(
                 self.wtp, self.parameters['months_per_year'],
                 self.parameters['payback_period'],
@@ -945,7 +951,7 @@ class Link():
 
 def _calculate_benefit_cost_ratio(benefits, costs):
     try:
-        return round(benefits / costs)
+        return benefits / costs
     except ZeroDivisionError:
         return 0
 

--- a/digital_comms/fixed_network/model.py
+++ b/digital_comms/fixed_network/model.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from math import ceil
 from abc import abstractmethod, abstractproperty, ABCMeta
 from typing import Dict
-import logging
 
 #####################
 # MODEL
@@ -490,12 +489,17 @@ class Asset(metaclass=ABCMeta):
     def upgrade(self, action):
         """Upgrade the asset's clients with an ``action``
 
-        If a leaf asset (e.g. a distribution point with no clients), upgrade
+        If a leaf asset (e.g. an Asset with no clients), upgrade
         self.
 
         Arguments
         ---------
         action : str
+
+        Notes
+        -----
+        Could check whether self is an instance of Distribution instead
+
         """
         if self._clients:
             if self.link is not None:
@@ -599,7 +603,7 @@ class Exchange(Asset):
         self.compute()
 
     @property
-    def upgrade_costs(self):
+    def upgrade_costs(self) -> Dict:
         upgrade_costs = {}
         upgrade_costs['fttp'] = (
             (self.parameters['costs_assets_exchange_fttp'] if self.fttp == 0 else 0)
@@ -624,12 +628,14 @@ class Exchange(Asset):
         self.list_of_asset_costs = []
         self.list_of_asset_costs.append({
             'id': self.id,
-            'costs_assets_exchange_fttp': (self.parameters['costs_assets_exchange_fttp'] if self.fttp == 0 else 0),
-            'link_upgrade_costs': (self.link.upgrade_costs['fibre'] if self.link is not None else 0),
+            'costs_assets_exchange_fttp':
+                (self.parameters['costs_assets_exchange_fttp'] if self.fttp == 0 else 0),
+            'link_upgrade_costs':
+                (self.link.upgrade_costs['fibre'] if self.link is not None else 0),
             'total_cost': (
-            (self.parameters['costs_assets_exchange_fttp'] if self.fttp == 0 else 0)
-            +
-            (self.link.upgrade_costs['fibre'] if self.link is not None else 0))
+                (self.parameters['costs_assets_exchange_fttp'] if self.fttp == 0 else 0)
+                +
+                (self.link.upgrade_costs['fibre'] if self.link is not None else 0))
         })
 
     def __repr__(self):
@@ -655,7 +661,6 @@ class Cabinet(Asset):
         Contains all parameters from 'digital_comms.yml'.
 
     """
-
     def __init__(self, data, clients, link, parameters):
         super().__init__(clients)
         # Asset parameters
@@ -754,7 +759,7 @@ class Distribution(Asset):
         self._total_prems = int(data['total_prems'])
         self.wta = float(data["wta"])
         self.wtp = int(data["wtp"])
-        self.adoption_desirability = False
+        self.adoption_desirability = False  # type: bool
 
         self.parameters = parameters
 

--- a/tests/fixed_network/test_fixed_adoption.py
+++ b/tests/fixed_network/test_fixed_adoption.py
@@ -217,7 +217,7 @@ def test_init_from_data():
     #'distribution_{EACOM}{4}' = 0.3
     #'distribution_{EACOM}{5}' = 0.2
 
-    actual_adoption_year_1 = update_adoption_desirability(system._distributions, 40, 'fttp')
+    actual_adoption_year_1 = update_adoption_desirability(system._distributions, 40)
 
     #actual_adoption_year_1 = [
     #('distribution_{EACAM}{3}', True), ('distribution_{EACAM}{2}', True)
@@ -225,7 +225,7 @@ def test_init_from_data():
 
     assert actual_adoption_year_1 == expected_adoption_year_1
 
-    actual_adoption_year_2 = update_adoption_desirability(system._distributions, 60, 'fttp')
+    actual_adoption_year_2 = update_adoption_desirability(system._distributions, 60)
 
     #actual_adoption_year_2 = [
     #('distribution_{EACAM}{2}', True)
@@ -233,17 +233,17 @@ def test_init_from_data():
 
     assert actual_adoption_year_2 == expected_adoption_year_2
 
-    actual_adoption_year_3 = update_adoption_desirability(system._distributions, 70, 'fttp')
+    actual_adoption_year_3 = update_adoption_desirability(system._distributions, 70)
 
     assert actual_adoption_year_3 == expected_adoption_year_3
 
-    actual_adoption_year_3 = update_adoption_desirability(system._distributions, 70, 'fttp')
+    actual_adoption_year_3 = update_adoption_desirability(system._distributions, 70)
 
     #actual_adoption_year_3 = []
 
     assert actual_adoption_year_3 == expected_adoption_year_3
 
-    actual_adoption_year_4 = update_adoption_desirability(system._distributions, 80, 'fttp')
+    actual_adoption_year_4 = update_adoption_desirability(system._distributions, 80)
 
     #actual_adoption_year_4 = [
     #('distribution_{EACOM}{4}', True)

--- a/tests/fixed_network/test_fixed_interventions.py
+++ b/tests/fixed_network/test_fixed_interventions.py
@@ -492,7 +492,7 @@ def test_fttp_s1(small_system_40):
     service_obligation_capacity = 10
 
     fttp_s1_expected_built_interventions = [
-        ('distribution_{EACAM}{2}', 'fttp', 's1_market_based_roll_out', 'market_based', 26880, 2087, 13)
+        ('distribution_{EACAM}{2}', 'fttp', 's1_market_based_roll_out', 'market_based', 26880.0, 2087, 12.879731672256828)
     ]
 
     #Total cost for the distribution downwards should be £2087
@@ -522,8 +522,8 @@ def test_fttp_s1_from_exchange(small_system_40):
     service_obligation_capacity = 10
 
     fttp_s1_expected_built_interventions = [
-        ('exchange_EACAM', 'fttp', 's1_market_based_roll_out', 'market_based', 49920, 57811, 1),
-        #('exchange_EACOM', 'fttp', 's1_market_based_roll_out', 'market_based', 57474)
+        ('exchange_EACAM', 'fttp', 's1_market_based_roll_out', 'market_based', 49920.0, 57811, 0.8635034854958399),
+        #('exchange_EACOM', 'fttp', 's1_market_based_roll_out', 'market_based', 57474.0)
     ]
 
     #Total cost for exchange_EACAM should be:
@@ -551,7 +551,7 @@ def test_fttp_s1_from_cabinet(small_system_40):
     service_obligation_capacity = 10
 
     fttp_s1_expected_built_interventions = [
-        ('cabinet_{EACAM}{P100}', 'fttp', 's1_market_based_roll_out', 'market_based', 49920, 7811, 6)
+        ('cabinet_{EACAM}{P100}', 'fttp', 's1_market_based_roll_out', 'market_based', 49920.0, 7811, 6.390987069517347)
     ]
 
     #Total cost for exchange_EACOM should be:
@@ -578,8 +578,8 @@ def test_fttp_s2_from_exchange(small_system_40):
     service_obligation_capacity = 10
 
     fttp_s2_expected_built_interventions = [
-        ('exchange_EACAM', 'fttp', 's2_rural_based_subsidy', 'market_based', 49920, 57811, 1),
-        ('exchange_EACOM', 'fttp', 's2_rural_based_subsidy', 'subsidy_based', 0, 57474, 0),
+        ('exchange_EACAM', 'fttp', 's2_rural_based_subsidy', 'market_based', 49920.0, 57811, 0.8635034854958399),
+        ('exchange_EACOM', 'fttp', 's2_rural_based_subsidy', 'subsidy_based', 0, 57474.0, 0),
         ]
 
     #build interventions
@@ -601,8 +601,8 @@ def test_fttp_s3(small_system_40):
     service_obligation_capacity = 10
 
     fttp_s3_expected_built_interventions = [
-        ('exchange_EACAM', 'fttp', 's3_outside_in_subsidy', 'market_based', 49920, 57811, 1),
-        ('exchange_EACOM', 'fttp', 's3_outside_in_subsidy', 'subsidy_based', 0, 57474, 0),
+        ('exchange_EACAM', 'fttp', 's3_outside_in_subsidy', 'market_based', 49920.0, 57811, 0.8635034854958399),
+        ('exchange_EACOM', 'fttp', 's3_outside_in_subsidy', 'subsidy_based', 0, 57474.0, 0.0),
         ]
 
     #Total cost should be £1837
@@ -647,7 +647,7 @@ def test_fttdp_s1_from_exchange(small_system_40):
     service_obligation_capacity = 10
 
     fttdp_s1_expected_built_interventions = [
-        ('exchange_EACAM', 'fttdp', 's1_market_based_roll_out', 'market_based',  49920, 32450, 2),
+        ('exchange_EACAM', 'fttdp', 's1_market_based_roll_out', 'market_based',  49920.0, 32450, 1.538366718027735),
     ]
 
     #Total cost should be £32400
@@ -676,7 +676,7 @@ def test_budget(small_system_80):
     service_obligation_capacity = 10
 
     expected_budget_constrained_interventions = [
-        ('distribution_{EACAM}{1}', 'fttp', 's1_market_based_roll_out', 'market_based', 30720, 1837, 17)
+        ('distribution_{EACAM}{1}', 'fttp', 's1_market_based_roll_out', 'market_based', 30720.0, 1837, 16.72291780076211)
     ]
 
     #Total cost should be £1837

--- a/tests/fixed_network/test_fixed_interventions.py
+++ b/tests/fixed_network/test_fixed_interventions.py
@@ -249,9 +249,9 @@ def technology():
 @pytest.fixture
 def small_system_40(base_system, technology):
 
-    #40% want to adopt in total
+    # 40% want to adopt in total
     distribution_adoption_desirability_ids = update_adoption_desirability(
-        base_system._distributions, 40, technology
+        base_system._distributions, 40
     )
 
     #update model adoption desirability
@@ -262,12 +262,12 @@ def small_system_40(base_system, technology):
 @pytest.fixture
 def small_system_80(base_system):
 
-    #40% want to adopt in total
+    # 40% want to adopt in total
     distribution_adoption_desirability_ids = update_adoption_desirability(
-        base_system._distributions, 80, technology
+        base_system._distributions, 80
     )
 
-    #update model adoption desirability
+    # update model adoption desirability
     base_system.update_adoption_desirability(distribution_adoption_desirability_ids)
 
     return base_system

--- a/tests/fixed_network/test_fixed_model.py
+++ b/tests/fixed_network/test_fixed_model.py
@@ -104,10 +104,12 @@ def base_system():
 
     return system
 
+
 @pytest.fixture
 def technology():
 
     return 'fttp'
+
 
 @pytest.fixture
 def small_system(base_system, technology):
@@ -121,6 +123,101 @@ def small_system(base_system, technology):
     base_system.update_adoption_desirability(distribution_adoption_desirability_ids)
 
     return base_system
+
+
+class TestUpgradeExchange:
+    """
+    """
+
+    def test_compute_exchange(self, base_system):
+
+        actual = base_system._exchanges[0]
+        assert actual.id == 'exchange_EACAM'
+        assert actual.fttp == 0
+        assert actual.fttdp == 0
+        assert actual.fttc == 5
+        assert actual.docsis3 == 5
+        assert actual.adsl == 20
+        assert actual.total_prems == 20
+
+        intervention_list = [('exchange_EACAM', 'fttp')]
+        base_system.upgrade(intervention_list)
+
+        actual.compute()
+
+        assert actual.id == 'exchange_EACAM'
+        assert actual.fttp == 20
+        assert actual.fttdp == 0
+        assert actual.fttc == 0
+        assert actual.docsis3 == 0
+        assert actual.adsl == 0
+        assert actual.total_prems == 20
+
+    def test_upgrade_exchange_base(self, base_system):
+
+        actual = base_system._exchanges[0]
+        assert actual.id == 'exchange_EACAM'
+        assert actual.fttp == 0
+        assert actual.fttdp == 0
+        assert actual.fttc == 5
+        assert actual.docsis3 == 5
+        assert actual.adsl == 20
+        assert actual.total_prems == 20
+        assert isinstance(actual._clients, list)
+
+        intervention_list = [('exchange_EACAM', 'fttp')]
+        base_system.upgrade(intervention_list)
+        actual = base_system._exchanges[0]
+        assert actual.fttp == 20
+        assert actual.adsl == 0
+
+    def test_upgrade_exchange(self, small_system):
+
+        intervention_list = [('exchange_EACAM', 'fttp')]
+        small_system.upgrade(intervention_list)
+
+        actual = small_system._exchanges[0]
+
+        assert actual.id == 'exchange_EACAM'
+        assert actual.fttp == 20
+        assert actual.fttdp == 0
+        assert actual.fttc == 0
+        assert actual.docsis3 == 0
+        assert actual.adsl == 0
+        assert actual.total_prems == 20
+        assert isinstance(actual._clients, list)
+
+    def test_sequence_upgrade_exchange(self, small_system):
+
+        intervention_list = [('exchange_EACAM', 'fttp')]
+        small_system.upgrade(intervention_list)
+
+        actual = small_system._exchanges[0]
+
+        assert actual.id == 'exchange_EACAM'
+        assert actual.fttp == 20
+        assert actual.fttdp == 0
+        assert actual.fttc == 0
+        assert actual.docsis3 == 0
+        assert actual.adsl == 0
+        assert actual.total_prems == 20
+        assert isinstance(actual._clients, list)
+
+        intervention_list = [('exchange_EACAM', 'fttdp')]
+        small_system.upgrade(intervention_list)
+
+        actual = small_system._exchanges[0]
+
+        assert actual.id == 'exchange_EACAM'
+        assert actual.fttp == 0
+        assert actual.fttdp == 20
+        assert actual.fttc == 0
+        assert actual.docsis3 == 5
+        assert actual.adsl == 20
+        assert actual.total_prems == 20
+        assert isinstance(actual._clients, list)
+
+
 
 def test_coverage(small_system):
 
@@ -322,7 +419,7 @@ def test_fttdp_upgrade_distributions(small_system):
     telco_match_funding = 2000
     service_obligation_capacity = 10
 
-    #build interventions
+    # build interventions
     built_interventions = decide_interventions(
         small_system._distributions, year, technology, policy, annual_budget, adoption_cap,
         subsidy, telco_match_funding, service_obligation_capacity, 'distribution')
@@ -361,6 +458,9 @@ def test_fttdp_upgrade_distributions(small_system):
 #         subsidy, telco_match_funding, service_obligation_capacity, 'exchange')
 #     print(fttp_s1_built_interventions)
 #     assert fttp_s1_built_interventions == 'fail'
+
+
+
 
 
 def test_enhanced_fttp_capacity_at_lad(small_system):

--- a/tests/fixed_network/test_fixed_model.py
+++ b/tests/fixed_network/test_fixed_model.py
@@ -114,12 +114,11 @@ def technology():
 @pytest.fixture
 def small_system(base_system, technology):
 
-    #40% want to adopt in total
+    # 40% want to adopt in total
     distribution_adoption_desirability_ids = update_adoption_desirability(
-        base_system._distributions, 40, technology
-    )
+        base_system._distributions, 40)
 
-    #update model adoption desirability
+    # update model adoption desirability
     base_system.update_adoption_desirability(distribution_adoption_desirability_ids)
 
     return base_system

--- a/tests/fixed_network/test_fixed_model.py
+++ b/tests/fixed_network/test_fixed_model.py
@@ -203,6 +203,8 @@ class TestUpgradeExchange:
         assert actual.total_prems == 20
         assert isinstance(actual._clients, list)
 
+        small_system.update_adoption_desirability([('distribution_{EACAM}{795}', True)])
+
         intervention_list = [('exchange_EACAM', 'fttdp')]
         small_system.upgrade(intervention_list)
 
@@ -212,8 +214,8 @@ class TestUpgradeExchange:
         assert actual.fttp == 0
         assert actual.fttdp == 20
         assert actual.fttc == 0
-        assert actual.docsis3 == 5
-        assert actual.adsl == 20
+        assert actual.docsis3 == 0
+        assert actual.adsl == 0
         assert actual.total_prems == 20
         assert isinstance(actual._clients, list)
 


### PR DESCRIPTION
Hi @edwardoughton 

In digging deeper into the fixed network code, I had a look at how to generalise the Exchange/Cabinet/Distribution Point objects in `model.py`.

My main reason for doing this was to better understand the interaction between the `adoption_desirability` flag and the `upgrade` method.

I've created a new Asset class, which each of Exchange/Cabinet and Distribution classes now inherit. The Asset class holds all of the shared functionality. For example, note that:

- I have used the `@property` decorator to denote read-only access to the asset's attributes e.g. self.fttp now calls the fttp property which computes the sum of fttp counts in the list of clients.
- Many of the computations within the `compute` methods have been simplified to remove duplicate code (e.g. iterate over list of technologies) and also added as properties so they are computed on demand
- `@lru_cache` is used for performance reasons - it automates the caching of data when a function is called repeatedly, as is happening here
- your tests were instrumental in enabling this - all your tests are passing.  I have a failing test which I wanted to discuss with you
- Following this refactor, `Exchange` and `Cabinet` are very similar in functionality. They differ only in their `compute` and `upgrade_costs` methods
- The `Distribution` asset is a special case

The model's design and behaviour is now easier to understand - each asset computes a set of statistics based on the clients nested inside it.